### PR TITLE
Small fixes to `shush.py`

### DIFF
--- a/modal/shush.py
+++ b/modal/shush.py
@@ -9,11 +9,21 @@ from modal import (
     functions,
 )
 from fastapi import Request, FastAPI, responses
+from fastapi.middleware.cors import CORSMiddleware
 import tempfile
 
 MODEL_DIR = "/model"
 
 web_app = FastAPI()
+
+
+web_app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 def download_model():
@@ -126,7 +136,7 @@ async def get_completion(request: Request):
     return result
 
 
-@stub.function(allow_concurrent_inputs=80)
+@stub.function(allow_concurrent_inputs=4)
 @asgi_app()
 def entrypoint():
     return web_app


### PR DESCRIPTION
- Removes the `@stub.function` from the FastAPI endpoints because that doesn't do anything
- Uses the default image for the FastAPI app, because that doesn't print the confusing NVIDIA warning
- Adds CORS policy, which was probably silently causing this issue https://github.com/arihanv/Shush/issues/5

![image](https://github.com/arihanv/Shush/assets/5786378/1380a153-d760-463a-8d4e-9f85630808ad)


Works after that!